### PR TITLE
Config as an option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,14 @@ npm install -g samson-cli
 You should create a `samsonrc.json` file in each of your project directories. `samson` will look for it when you run the tool. The file should have this shape:
 
 ```json
-{                                                                             
-  "url": "http://my-samson-url.com",                              
-  "project": "myProjectName",                                                        
-  "auth": "<authentication cookie>"                                            
-}  
+{
+  "url": "http://my-samson-url.com",
+  "project": "myProjectName",
+  "auth": "<authentication cookie>",
+  "samson": {
+    "production": true
+  }
+}
 ```
 
 The `auth` key expects the value of your Samson session cookie. We still don't have a better authentication system (perhaps based in a Samson user token) due to Samson API limitations.
@@ -70,6 +73,17 @@ Syntax:
 ```
 samson stages
 ```
+
+## Options
+
+### `-c | --config`
+You can specify a custom config, in json format
+
+Syntax:
+```
+samson <command> -c '{ "url": "http://my-samson-url.com", ...}'
+```
+Note: You may not need to have a `samsonrc.json` file in order to use the program if the config is specified this way, but some autocompletion features will be disabled
 
 ## To do
 - [ ] Authenticate using Samson token instead of the session cookie

--- a/src/program/builds.js
+++ b/src/program/builds.js
@@ -1,5 +1,4 @@
 const helpers = require('./helpers')
-const config = require('../config')
 const moment = require('moment')
 
 const showBuilds = builds => {
@@ -11,7 +10,7 @@ const showBuilds = builds => {
   })))
 }
 
-module.exports = api => () => {
+module.exports = (api, config) => (options) => {
   api.getProjects()
   .then(helpers.getProjectId(config.project))
   .then(api.getBuilds)

--- a/src/program/deploys.js
+++ b/src/program/deploys.js
@@ -1,6 +1,5 @@
 const moment = require('moment')
 const chalk = require('chalk')
-const config = require('../config')
 const h = require('./helpers')
 const ora = require('ora')
 const EventSource = require('eventsource')
@@ -14,7 +13,7 @@ const showDeploys = deploys => {
   })))
 }
 
-module.exports.show = api => () => {
+module.exports.show = (api, config) => () => {
   api.getProjects()
   .then(h.getProjectId(config.project))
   .then(api.getDeploys)
@@ -57,7 +56,7 @@ const Spinners = (tasks) => {
   }
 }
 
-module.exports.deploy = api => (stage, reference, options) => {
+module.exports.deploy = (api, config) => (stage, reference, options) => {
   const spinners = Spinners([
     'Fetching project metadata...',
     'Authenticating...',

--- a/src/program/stages.js
+++ b/src/program/stages.js
@@ -1,4 +1,3 @@
-const config = require('../config')
 const h = require('./helpers')
 
 const showStages = stages => {
@@ -7,7 +6,7 @@ const showStages = stages => {
   })))
 }
 
-module.exports = api => () => {
+module.exports = (api, config) => (options) => {
   api.getProjects()
   .then(h.getProjectId(config.project))
   .then(api.getStages)

--- a/src/tab-completion/index.js
+++ b/src/tab-completion/index.js
@@ -4,8 +4,8 @@ const tab = require('tabtab')({
   cache: false
 })
 
-const config = require('../config')
-const api = require('../api')(config.url, config.auth, !config.samson.production)
+// const config = require('../config')
+// const api = require('../api')(config.url, config.auth, !config.samson.production)
 const h = require('../program/helpers')
 
 tab.on(CMD, (data, done) => {

--- a/src/tab-completion/index.js
+++ b/src/tab-completion/index.js
@@ -4,8 +4,6 @@ const tab = require('tabtab')({
   cache: false
 })
 
-// const config = require('../config')
-// const api = require('../api')(config.url, config.auth, !config.samson.production)
 const h = require('../program/helpers')
 
 tab.on(CMD, (data, done) => {
@@ -22,18 +20,25 @@ tab.on(CMD, (data, done) => {
   ])
 })
 
-tab.on('deploy', (data, done) => {
-  if (data.prev === 'deploy') {
-    api.getProjects()
-    .then(h.getProjectId(config.project))
-    .then(api.getStages)
-    .then(stages => done(null, stages.map(s => s.name)))
-    .catch(done)
-  } else {
-    api.getBranches()
-    .then(branches => done(null, branches))
-    .catch(done)
-  }
-})
+try {
+  const config = require('../config')
+  const api = require('../api')(config.url, config.auth, !config.samson.production)
+
+  tab.on('deploy', (data, done) => {
+    if (data.prev === 'deploy') {
+      api.getProjects()
+        .then(h.getProjectId(config.project))
+        .then(api.getStages)
+        .then(stages => done(null, stages.map(s => s.name)))
+        .catch(done)
+    } else {
+      api.getBranches()
+        .then(branches => done(null, branches))
+        .catch(done)
+    }
+  })
+} catch (err) {
+  console.log('Could not setup deploy autocomplete')
+}
 
 tab.start()


### PR DESCRIPTION
## Rationale
I'm trying to use samson-cli to deploy multiple projects, periodically. For this purpose I've set up a cron that makes use of this tool. I've found two different problems so far.

- I need a different config file for each project I want to deploy. This is kind of a waste, since the only thing that differs from file to file is the project name
- I can't specify a custom location for the config file.

For our particular use-case the approach that fits better is to specify the config via options

## Implementation
Samson cli config can now be specified in the following way: `samson [command] -c '{"url": "deployurl", ... }'`, and the `samsonrc.json` file is no longer required

## Gotcha
Tab completion module enable deploys completion only if the `samsonrc.json` file is present
